### PR TITLE
Fix NoMethodError: undefined method `wait_readable' for #<Socket>

### DIFF
--- a/lib/kontena-websocket-client.rb
+++ b/lib/kontena-websocket-client.rb
@@ -1,3 +1,4 @@
+require 'io/wait'
 require 'openssl'
 require 'socket'
 require 'websocket/driver'

--- a/lib/kontena-websocket-client.rb
+++ b/lib/kontena-websocket-client.rb
@@ -1,3 +1,8 @@
+require 'openssl'
+require 'socket'
+require 'websocket/driver'
+
+# OpenSSL::SSL::SSLSocket#wait_readable, #wait_writable
 require_relative './kontena/websocket/openssl_patch'
 
 module Kontena

--- a/lib/kontena/websocket/client.rb
+++ b/lib/kontena/websocket/client.rb
@@ -1,8 +1,3 @@
-require 'websocket/driver'
-require 'forwardable'
-require 'socket'
-require 'openssl'
-
 # Threadsafe: while the #run method is reading/parsing incoming websocket frames, the #send/#ping/#close methods
 # can be called by other threads.
 # The #run (on_open), #on_message and #on_pong blocks will be called from the #run thread.


### PR DESCRIPTION
Older versions of ruby prior to 2.3 did not include the `Socket` methods provided by [`io/wait`](https://ruby-doc.org/stdlib-2.3.3/libdoc/io/wait/rdoc/IO.html).