### PR TITLE
Fix flaky travis specs

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
+--require spec_helper
 --format documentation
 --color

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_install: gem install bundler -v 1.15.1
 install:
   - bundle install --path vendor/bundle
 script:
-  - LOG_LEVEL=0 bundle exec rspec
+  - bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_install: gem install bundler -v 1.15.1
 install:
   - bundle install --path vendor/bundle
 script:
-  - LOG_LEVEL=debug bundle exec rspec
+  - LOG_LEVEL=0 bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_install: gem install bundler -v 1.15.1
 install:
   - bundle install --path vendor/bundle
 script:
-  - bundle exec rspec
+  - LOG_LEVEL=debug bundle exec rspec

--- a/lib/kontena/websocket/client.rb
+++ b/lib/kontena/websocket/client.rb
@@ -414,9 +414,9 @@ class Kontena::Websocket::Client
   # @yield [driver]
   # @yieldparam driver [Websocket::Driver]
   def with_driver
-    fail "not connected" unless @driver
-
     @mutex.synchronize {
+      fail "not connected" unless @driver
+
       yield @driver
     }
   end

--- a/spec/kontena/websocket/client_connection_spec.rb
+++ b/spec/kontena/websocket/client_connection_spec.rb
@@ -1,6 +1,6 @@
 require 'kontena-websocket-client'
 
-describe Kontena::Websocket::Client::Connection do
+RSpec.describe Kontena::Websocket::Client::Connection do
   let(:uri) { URI.parse('ws://socket.example.com') }
   let(:socket) { instance_double(TCPSocket) }
 

--- a/spec/kontena/websocket/client_spec.rb
+++ b/spec/kontena/websocket/client_spec.rb
@@ -1,6 +1,6 @@
 require 'kontena-websocket-client'
 
-describe Kontena::Websocket::Client do
+RSpec.describe Kontena::Websocket::Client do
   subject { described_class.new('ws://socket.example.com') }
 
   describe '#initialize' do

--- a/spec/kontena/websocket/test_spec.rb
+++ b/spec/kontena/websocket/test_spec.rb
@@ -4,7 +4,7 @@ require 'kontena-websocket-client'
 RSpec.describe Kontena::Websocket::Client do
   let(:logger) {
     logger = Logger.new(STDERR)
-    logger.level = ENV['LOG_LEVEL'] || Logger::INFO
+    logger.level = (ENV['LOG_LEVEL'] || Logger::INFO).to_i
     logger.progname = 'test'
     logger
   }

--- a/spec/kontena/websocket/test_spec.rb
+++ b/spec/kontena/websocket/test_spec.rb
@@ -4,6 +4,7 @@ require 'kontena-websocket-client'
 RSpec.describe Kontena::Websocket::Client do
   let(:logger) {
     logger = Logger.new(STDERR)
+    logger.level = ENV['LOG_LEVEL'] || Logger::INFO
     logger.progname = 'test'
     logger
   }

--- a/spec/kontena/websocket/test_spec.rb
+++ b/spec/kontena/websocket/test_spec.rb
@@ -71,6 +71,8 @@ RSpec.describe Kontena::Websocket::Client do
     let(:options) { { open_timeout: 0.5 }}
 
     context "that immediately closes the connection" do
+      let(:options) { { open_timeout: 1.0 }}
+
       let(:server_thread) do
         Thread.new do
           loop do

--- a/spec/kontena/websocket/test_spec.rb
+++ b/spec/kontena/websocket/test_spec.rb
@@ -3,7 +3,9 @@ require 'kontena-websocket-client'
 
 RSpec.describe Kontena::Websocket::Client do
   let(:logger) {
-    Logger.new(STDERR)
+    logger = Logger.new(STDERR)
+    logger.progname = 'test'
+    logger
   }
   before do
     Thread.abort_on_exception = true

--- a/spec/kontena/websocket/test_spec.rb
+++ b/spec/kontena/websocket/test_spec.rb
@@ -66,7 +66,7 @@ describe Kontena::Websocket::Client do
     end
 
     let(:url) { "ws://127.0.0.1:#{port}" }
-    let(:options) { { open_timeout: 0.1 }}
+    let(:options) { { open_timeout: 0.5 }}
 
     context "that immediately closes the connection" do
       let(:server_thread) do
@@ -104,7 +104,7 @@ describe Kontena::Websocket::Client do
       it 'raises an open timeout' do
         expect{
           subject.connect
-        }.to raise_error(Kontena::Websocket::TimeoutError, /read timeout after 0.\d+s while waiting 0.1s for open/)
+        }.to raise_error(Kontena::Websocket::TimeoutError, /read timeout after 0.\d+s while waiting 0.5s for open/)
       end
     end
 
@@ -124,9 +124,14 @@ describe Kontena::Websocket::Client do
                 "Connection: upgrade",
               ].join("\r\n"))
 
-              loop do
-                client.write("X-Foo: bar\r\n")
-                Thread.pass
+              begin
+                loop do
+                  client.write("X-Foo: bar\r\n")
+                  Thread.pass
+                end
+              rescue Errno::ECONNRESET => exc
+                # expected
+                logger.debug "server write error: #{exc}"
               end
             ensure
               client.close
@@ -138,7 +143,7 @@ describe Kontena::Websocket::Client do
       it 'raises an open timeout' do
         expect{
           subject.connect
-        }.to raise_error(Kontena::Websocket::TimeoutError, /read (deadline expired|timeout after 0.\d+s) while waiting 0.1s for open/)
+        }.to raise_error(Kontena::Websocket::TimeoutError, /read (deadline expired|timeout after 0.\d+s) while waiting 0.5s for open/)
       end
     end
 

--- a/spec/kontena/websocket/test_spec.rb
+++ b/spec/kontena/websocket/test_spec.rb
@@ -339,6 +339,7 @@ describe Kontena::Websocket::Client do
                     "",
                   ].join("\r\n"))
                   socket.close
+                  return
                 end
               end
 
@@ -370,7 +371,6 @@ describe Kontena::Websocket::Client do
               end
               driver.on :close do |event|
                 logger.info("websocket server close: #{event}")
-                socket.close
               end
 
               loop do

--- a/spec/kontena/websocket/test_spec.rb
+++ b/spec/kontena/websocket/test_spec.rb
@@ -1,7 +1,7 @@
 require 'tempfile'
 require 'kontena-websocket-client'
 
-describe Kontena::Websocket::Client do
+RSpec.describe Kontena::Websocket::Client do
   let(:logger) {
     Logger.new(STDERR)
   }

--- a/spec/kontena/websocket/test_spec.rb
+++ b/spec/kontena/websocket/test_spec.rb
@@ -77,9 +77,16 @@ RSpec.describe Kontena::Websocket::Client do
       let(:server_thread) do
         Thread.new do
           loop do
+            logger.debug "accept..."
             client = tcp_server.accept
-            client.readpartial(1024)
-            client.close
+
+            begin
+              logger.debug "read..."
+              client.readpartial(1024)
+            ensure
+              logger.debug "close..."
+              client.close
+            end
           end
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require "bundler/setup"
-require "kontena/websocket/client"
+require "kontena-websocket-client"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,4 +11,8 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.before :all do
+    Kontena::Websocket::Logging.initialize_logger(STDERR, ENV['LOG_LEVEL'] || Logger::INFO)
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,6 @@ RSpec.configure do |config|
   end
 
   config.before :all do
-    Kontena::Websocket::Logging.initialize_logger(STDERR, ENV['LOG_LEVEL'] || Logger::INFO)
+    Kontena::Websocket::Logging.initialize_logger(STDERR, (ENV['LOG_LEVEL'] || Logger::INFO).to_i)
   end
 end


### PR DESCRIPTION
The websocket client test specs (which connect to a test server on localhost) seem to be flaky when running on travis.