### PR TITLE
Fix ruby <= 2.2 false timeout on EOF

### DIFF
--- a/lib/kontena-websocket-client.rb
+++ b/lib/kontena-websocket-client.rb
@@ -1,4 +1,3 @@
-require 'io/wait'
 require 'openssl'
 require 'socket'
 require 'websocket/driver'

--- a/lib/kontena/websocket/client/connection.rb
+++ b/lib/kontena/websocket/client/connection.rb
@@ -33,7 +33,7 @@ class Kontena::Websocket::Client::Connection
     def wait_socket_readable(socket, timeout = nil)
       debug "wait read: timeout=#{timeout}"
 
-      IO.select([self], nil, nil, timeout) or raise Kontena::Websocket::TimeoutError, "read timeout after #{timeout}s"
+      IO.select([socket], nil, nil, timeout) or raise Kontena::Websocket::TimeoutError, "read timeout after #{timeout}s"
     end
 
     # @param socket [Socket]
@@ -42,7 +42,7 @@ class Kontena::Websocket::Client::Connection
     def wait_socket_writable(socket, timeout = nil)
       debug "wait write: timeout=#{timeout}"
 
-      IO.select(nil, [self], nil, timeout) or raise Kontena::Websocket::TimeoutError, "write timeout after #{timeout}s"
+      IO.select(nil, [socket], nil, timeout) or raise Kontena::Websocket::TimeoutError, "write timeout after #{timeout}s"
     end
   end
 

--- a/lib/kontena/websocket/client/connection.rb
+++ b/lib/kontena/websocket/client/connection.rb
@@ -7,19 +7,23 @@ class Kontena::Websocket::Client::Connection
     # @param socket [Socket]
     # @param timeout [Float] default (nil) blocks indefinitely
     # @raise [Kontena::Websocket::TimeoutError]
-    def wait_socket_readable(socket, timeout = nil)
+    def wait_socket_readable!(socket, timeout = nil)
       debug "wait read: timeout=#{timeout}"
 
-      @socket.wait_readable(timeout) or raise Kontena::Websocket::TimeoutError, "read timeout after #{timeout}s"
+      unless @socket.wait_readable(timeout)
+        raise Kontena::Websocket::TimeoutError, "read timeout after #{timeout}s"
+      end
     end
 
     # @param socket [Socket]
     # @param timeout [Float] default (nil) blocks indefinitely
     # @raise [Kontena::Websocket::TimeoutError]
-    def wait_socket_writable(socket, timeout = nil)
+    def wait_socket_writable!(socket, timeout = nil)
       debug "wait write: timeout=#{timeout}"
 
-      @socket.wait_writable(timeout) or raise Kontena::Websocket::TimeoutError, "write timeout after #{timeout}s"
+      unless @socket.wait_writable(timeout)
+        raise Kontena::Websocket::TimeoutError, "write timeout after #{timeout}s"
+      end
     end
   end
 
@@ -30,19 +34,23 @@ class Kontena::Websocket::Client::Connection
     # @param socket [Socket]
     # @param timeout [Float] default (nil) blocks indefinitely
     # @raise [Kontena::Websocket::TimeoutError]
-    def wait_socket_readable(socket, timeout = nil)
+    def wait_socket_readable!(socket, timeout = nil)
       debug "wait read: timeout=#{timeout}"
 
-      IO.select([socket], nil, nil, timeout) or raise Kontena::Websocket::TimeoutError, "read timeout after #{timeout}s"
+      unless IO.select([socket], nil, nil, timeout)
+        raise Kontena::Websocket::TimeoutError, "read timeout after #{timeout}s"
+      end
     end
 
     # @param socket [Socket]
     # @param timeout [Float] default (nil) blocks indefinitely
     # @raise [Kontena::Websocket::TimeoutError]
-    def wait_socket_writable(socket, timeout = nil)
+    def wait_socket_writable!(socket, timeout = nil)
       debug "wait write: timeout=#{timeout}"
 
-      IO.select(nil, [socket], nil, timeout) or raise Kontena::Websocket::TimeoutError, "write timeout after #{timeout}s"
+      unless IO.select(nil, [socket], nil, timeout)
+        raise Kontena::Websocket::TimeoutError, "write timeout after #{timeout}s"
+      end
     end
   end
 
@@ -76,10 +84,10 @@ class Kontena::Websocket::Client::Connection
   def nonblocking_timeout(timeout = nil, &block)
     return yield
   rescue IO::WaitReadable
-    wait_socket_readable(@socket, timeout) # raises Kontena::Websocket::TimeoutError
+    wait_socket_readable!(@socket, timeout) # raises Kontena::Websocket::TimeoutError
     retry
   rescue IO::WaitWritable
-    wait_socket_writable(@socket, timeout) # raises Kontena::Websocket::TimeoutError
+    wait_socket_writable!(@socket, timeout) # raises Kontena::Websocket::TimeoutError
     retry
   end
 

--- a/spec/kontena/websocket/client_connection_spec.rb
+++ b/spec/kontena/websocket/client_connection_spec.rb
@@ -10,42 +10,44 @@ RSpec.describe Kontena::Websocket::Client::Connection do
     expect(subject.url).to eq 'ws://socket.example.com'
   end
 
-  it 'writes to the socket' do
-    expect(socket).to receive(:write_nonblock).with('asdf').and_return(4)
+  describe '#write' do
+    it 'writes to the socket' do
+      expect(socket).to receive(:write_nonblock).with('asdf').and_return(4)
 
-    subject.write('asdf')
-  end
+      subject.write('asdf')
+    end
 
-  it 'writes a large string to the socket in multiple chunks' do
-    expect(socket).to receive(:write_nonblock).with('asdf' * 16).and_return(4 * 8)
-    expect(socket).to receive(:write_nonblock).with('asdf' * 8).and_return(4 * 4)
-    expect(socket).to receive(:write_nonblock).with('asdf' * 4).and_return(4 * 4)
+    it 'writes a large string to the socket in multiple chunks' do
+      expect(socket).to receive(:write_nonblock).with('asdf' * 16).and_return(4 * 8)
+      expect(socket).to receive(:write_nonblock).with('asdf' * 8).and_return(4 * 4)
+      expect(socket).to receive(:write_nonblock).with('asdf' * 4).and_return(4 * 4)
 
-    subject.write('asdf' * 16)
-  end
-
-  it 'waits on write without a timeout' do
-    expect(socket).to receive(:write_nonblock).with('asdf').and_raise(Class.new(Errno::ETIMEDOUT) do
-      include IO::WaitWritable
-    end)
-    expect(subject).to receive(:wait_socket_readable!).with(socket, nil).and_return(socket)
-    expect(socket).to receive(:write_nonblock).with('asdf').and_return(4)
-
-    subject.write('asdf')
-  end
-
-  context 'with a write timeout' do
-    subject { described_class.new(uri, socket, write_timeout: 1.0) }
+      subject.write('asdf' * 16)
+    end
 
     it 'waits on write without a timeout' do
       expect(socket).to receive(:write_nonblock).with('asdf').and_raise(Class.new(Errno::ETIMEDOUT) do
         include IO::WaitWritable
       end)
-      expect(subject).to receive(:wait_socket_writable!).with(socket, 1.0).and_return(nil)
+      expect(subject).to receive(:wait_socket_writable!).with(socket, nil).and_return(socket)
+      expect(socket).to receive(:write_nonblock).with('asdf').and_return(4)
 
-      expect{
-        subject.write('asdf')
-      }.to raise_error(Kontena::Websocket::TimeoutError, 'write timeout after 1.0s')
+      subject.write('asdf')
+    end
+
+    context 'with a write timeout' do
+      subject { described_class.new(uri, socket, write_timeout: 1.0) }
+
+      it 'waits on write without a timeout' do
+        expect(socket).to receive(:write_nonblock).with('asdf').and_raise(Class.new(Errno::ETIMEDOUT) do
+          include IO::WaitWritable
+        end)
+        expect(subject).to receive(:wait_socket_writable!).with(socket, 1.0).and_raise(Kontena::Websocket::TimeoutError, 'write timeout after 1.0s')
+
+        expect{
+          subject.write('asdf')
+        }.to raise_error(Kontena::Websocket::TimeoutError, 'write timeout after 1.0s')
+      end
     end
   end
 end

--- a/spec/kontena/websocket/client_connection_spec.rb
+++ b/spec/kontena/websocket/client_connection_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Kontena::Websocket::Client::Connection do
     expect(socket).to receive(:write_nonblock).with('asdf').and_raise(Class.new(Errno::ETIMEDOUT) do
       include IO::WaitWritable
     end)
-    expect(socket).to receive(:wait_writable).with(nil).and_return(socket)
+    expect(subject).to receive(:wait_socket_readable!).with(socket, nil).and_return(socket)
     expect(socket).to receive(:write_nonblock).with('asdf').and_return(4)
 
     subject.write('asdf')
@@ -41,7 +41,7 @@ RSpec.describe Kontena::Websocket::Client::Connection do
       expect(socket).to receive(:write_nonblock).with('asdf').and_raise(Class.new(Errno::ETIMEDOUT) do
         include IO::WaitWritable
       end)
-      expect(socket).to receive(:wait_writable).with(1.0).and_return(nil)
+      expect(subject).to receive(:wait_socket_writable!).with(socket, 1.0).and_return(nil)
 
       expect{
         subject.write('asdf')


### PR DESCRIPTION
Use `IO.select` instead of `wait_readable` on ruby <= 2.2, as it returns `nil` on EOF: https://github.com/ruby/ruby/commit/a60e00fde84929b2b5b3943107ce2bae3db14935