### PR TITLE
Fix ruby 2.4 invalid SSLVerifyError from verify_hostname 

### DIFF
--- a/lib/kontena-websocket-client.rb
+++ b/lib/kontena-websocket-client.rb
@@ -7,6 +7,7 @@ require_relative './kontena/websocket/openssl_patch'
 
 module Kontena
   module Websocket
+    require_relative './kontena/websocket/client/version'
     require_relative './kontena/websocket/logging'
     require_relative './kontena/websocket/error'
     require_relative './kontena/websocket/client'

--- a/lib/kontena/websocket/client.rb
+++ b/lib/kontena/websocket/client.rb
@@ -505,9 +505,17 @@ class Kontena::Websocket::Client
   # @return [OpenSSL::SSL::SSLContext]
   def ssl_context
     @ssl_context ||= OpenSSL::SSL::SSLContext.new().tap do |ssl_context|
-      ssl_context.set_params(**@ssl_params,
+      params = {
         cert_store: self.ssl_cert_store,
-      )
+        **@ssl_params
+      }
+
+      if Kontena::Websocket::Client.ruby_version? '2.4'
+        # prefer our own ssl_verify_cert! logic
+        params[:verify_hostname] = false
+      end
+
+      ssl_context.set_params(params)
     end
   end
 

--- a/lib/kontena/websocket/client/connection.rb
+++ b/lib/kontena/websocket/client/connection.rb
@@ -54,7 +54,7 @@ class Kontena::Websocket::Client::Connection
     end
   end
 
-  if (RUBY_VERSION.split('.').map{|x|x.to_i} <=> [2, 3]) >= 0
+  if Kontena::Websocket::Client.ruby_version? '2.3'
     require 'io/wait'
     include Waitable
   else

--- a/lib/kontena/websocket/client/version.rb
+++ b/lib/kontena/websocket/client/version.rb
@@ -1,7 +1,13 @@
-module Kontena
-  module Websocket
-    module Client
-      VERSION = "0.1.0"
-    end
+class Kontena::Websocket::Client
+  VERSION = "0.1.0"
+
+  # Running ruby >= version?
+  # @param gte_version [String]
+  # @return [Boolean]
+  def self.ruby_version?(gte_version)
+    ruby_version = RUBY_VERSION.split('.').map{|x|x.to_i}
+    gte_version = gte_version.split('.').map{|x|x.to_i}
+
+    return (ruby_version <=> gte_version) >= 0
   end
 end


### PR DESCRIPTION
The new ruby 2.4 default `OpenSSL::SSL::SSLContext#set_params` `verify_hostname: false` was raising `OpenSSL::SSL::SSLError: ....: certificate_verify_failed` with a `verify_result` of `OpenSSL::X509::V_OK` when the `verify_certificate_identity` check returns false. This resulted in `Kontena::Websocket::SSLVerifyError: certificate verify failed: ok`.

Disable the `verify_hostname` option, and preferr our own `ssl_verify_cert!` function instead, which raises much more informative `Kontena::Websocket::SSLVerifyError`s.