### PR TITLE
Benchmarking

### DIFF
--- a/benchmark/.gitignore
+++ b/benchmark/.gitignore
@@ -1,0 +1,1 @@
+websocket-echo-server

--- a/benchmark/benchmark.sh
+++ b/benchmark/benchmark.sh
@@ -9,7 +9,7 @@ go build -o $DIR/websocket-echo-server $DIR/websocket-echo-server.go
 
 killall websocket-echo-server || true
 $DIR/websocket-echo-server -quiet -drop &
-$DIR/websocket-benchmark.rb &
+
+$DIR/websocket-benchmark.rb
 
 trap "kill 0" INT EXIT
-wait

--- a/benchmark/benchmark.sh
+++ b/benchmark/benchmark.sh
@@ -7,8 +7,9 @@ DIR=$(dirname $0)
 go get -d github.com/gorilla/websocket
 go build -o $DIR/websocket-echo-server $DIR/websocket-echo-server.go
 
+killall websocket-echo-server || true
 $DIR/websocket-echo-server -quiet &
 $DIR/websocket-benchmark.rb &
 
-trap "kill 0" EXIT
+trap "kill 0" INT EXIT
 wait

--- a/benchmark/benchmark.sh
+++ b/benchmark/benchmark.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -uex
+
+DIR=$(dirname $0)
+
+go get -d github.com/gorilla/websocket
+go build -o $DIR/websocket-echo-server $DIR/websocket-echo-server.go
+
+$DIR/websocket-echo-server -quiet &
+$DIR/websocket-benchmark.rb &
+
+trap "kill 0" EXIT
+wait

--- a/benchmark/benchmark.sh
+++ b/benchmark/benchmark.sh
@@ -8,7 +8,7 @@ go get -d github.com/gorilla/websocket
 go build -o $DIR/websocket-echo-server $DIR/websocket-echo-server.go
 
 killall websocket-echo-server || true
-$DIR/websocket-echo-server -quiet &
+$DIR/websocket-echo-server -quiet -drop &
 $DIR/websocket-benchmark.rb &
 
 trap "kill 0" INT EXIT

--- a/benchmark/websocket-benchmark.rb
+++ b/benchmark/websocket-benchmark.rb
@@ -125,10 +125,22 @@ rates = (ENV['RATES'].split.map{|r| Integer(r)} || RATES)
 duration = (ENV['DURATION'] || 5.0).to_f
 message_size = (ENV['MESSAGE_SIZE'] || 1000).to_i
 
-HEADER = '%5ss %6s/s: %9s @ %9s/s (%5s%% ~ %5s%%) recv %9s @ %9ss'
-FORMAT = '%5.2fs %6d/s: %9d @ %9.2f/s (%5.2f%% ~ %5.2f%%) recv %9d @ %9.6fs'
+HEADER = '%5s  %6s/s: send %9s @ %9s/s (%5s%% ~ %5s%%) recv %9s @ %12s/s ~ %9s'
+FORMAT = '%5.2fs %6d/s: send %9d @ %9.2f/s (%5.2f%% ~ %5.2f%%) recv %9d @ %12s/s ~ %9.6fs'
 
-puts HEADER % ['time ', 'rate', 'count', 'rate', 'util', 'miss', 'count', 'avg lat ']
+def si(val)
+  if val > 10**9
+    '%.3fG' % [val / 10**9]
+  elsif val > 10**6
+    '%.3fM' % [val / 10**6]
+  elsif val > 10**3
+    '%.3fK' % [val / 10**3]
+  else
+    '%.3f ' % [val]
+  end
+end
+
+puts HEADER % ['time ', 'rate', 'count', 'messages', 'util', 'miss', 'count', 'bytes', 'avg latency']
 
 for rate in rates
   options = {
@@ -144,6 +156,6 @@ for rate in rates
   puts FORMAT % [
     duration, rate,
     send_stats[:count], send_stats[:rate], send_stats[:util] * 100.0, send_stats[:miss] * 100.0,
-    read_stats[:count], read_stats[:latency_avg],
+    read_stats[:count], si(read_stats[:bytes] / send_stats[:time]), read_stats[:latency_avg],
   ]
 end

--- a/benchmark/websocket-benchmark.rb
+++ b/benchmark/websocket-benchmark.rb
@@ -1,0 +1,138 @@
+#!/usr/bin/env ruby
+
+require 'logger'
+require 'kontena-websocket-client'
+
+Thread.abort_on_exception = true
+
+log_level = ENV['LOG_LEVEL'] || Logger::WARN
+
+$logger = Logger.new(STDERR)
+$logger.level = log_level
+$logger.progname = 'websocket-benchmark'
+
+Kontena::Websocket::Logging.initialize_logger(STDERR, log_level)
+
+def with_rate(rate, duration, &block)
+  t0 = Time.now
+  interval = 1.0 / rate
+  count = 0
+  total_yield = 0.0
+  count_miss = 0
+
+  while (t = Time.now) < t0 + duration
+    yield t
+
+    t_yield = Time.now
+
+    count += 1
+    total_yield += (t_yield - t)
+
+    t_next = t0 + count * interval
+
+    if t_next > t_yield
+      sleep t_next - t_yield
+    else
+      count_miss += 1
+    end
+  end
+
+  t_total = t - t0
+
+  return {
+    time: t_total,
+    count: count,
+    rate: count / t_total,
+    util: total_yield / duration,
+    miss: (count_miss / count),
+  }
+end
+
+def websocket_benchark_sender(client, rate: 1000, duration: 5.0, message_size: 1000)
+  total_size = 0
+
+  padding = 'X'*(message_size - 15)
+
+  stats = with_rate(rate, duration) do |t|
+    client.send('%15.6f %s' % [t.to_f, padding])
+
+    total_size += message_size
+  end
+
+  client.close()
+
+  return stats.merge(
+    bytes: total_size,
+  )
+end
+
+def websocket_benchmark_reader(client)
+  count = 0
+  bytes = 0
+  latency_total = 0.0
+
+  client.read do |message|
+    t = Time.now.to_f
+    t_s, padding = message.split(' ', 2)
+    t_f = t_s.to_f
+
+    count += 1
+    bytes += message.length
+    latency_total += (t - t_f)
+  end
+
+  return {
+    count: count,
+    bytes: bytes,
+    latency_avg: latency_total / count,
+  }
+end
+
+def websocket_benchmark(url, **options)
+  send_thread = nil
+  read_stats = nil
+
+  Kontena::Websocket::Client.connect(url) do |client|
+    $logger.info "connect: #{client}"
+
+    send_thread = Thread.new {
+      websocket_benchark_sender(client, **options)
+    }
+
+    read_stats = websocket_benchmark_reader(client)
+  end
+
+  send_stats = send_thread.value
+
+  return send_stats, read_stats
+end
+
+url = ENV['URL'] || 'ws://localhost:8080/echo'
+
+RATES = [1, 10, 100, 1000, 3000, 5000, 10000]
+rates = (ENV['RATES'].split.map{|r| Integer(r)} || RATES)
+duration = (ENV['DURATION'] || 5.0).to_f
+message_size = (ENV['MESSAGE_SIZE'] || 1000).to_i
+
+HEADER = '%5ss %6s/s: %9s @ %9s/s (%5s%% + %5s%%) recv %9s @ ~%6ss'
+FORMAT = '%5.2fs %6d/s: %9d @ %9.2f/s (%5.2f%% + %5.2f%%) recv %9d @ ~%6.3fs'
+
+puts HEADER % ['time ', 'rate', 'count', 'rate', 'util', 'miss', 'count', 'latency ']
+
+for rate in rates
+  options = {
+    rate: rate,
+    duration: duration,
+    message_size: message_size,
+  }
+
+  $logger.info "benchmark: #{url} #{options}"
+
+  send_stats, read_stats = websocket_benchmark(url, **options)
+
+  puts FORMAT % [
+    duration, rate,
+    send_stats[:count], send_stats[:rate], send_stats[:util] * 100.0, send_stats[:miss] * 100.0,
+    read_stats[:count], read_stats[:latency_avg],
+  ]
+end

--- a/benchmark/websocket-benchmark.rb
+++ b/benchmark/websocket-benchmark.rb
@@ -121,7 +121,7 @@ end
 url = ENV['URL'] || 'ws://localhost:8080/echo'
 
 RATES = [1, 10, 100, 1000, 3000, 5000, 10000]
-rates = (ENV['RATES'].split.map{|r| Integer(r)} || RATES)
+rates = (ENV['RATES']&.split&.map{|r| Integer(r)} || RATES)
 duration = (ENV['DURATION'] || 5.0).to_f
 message_size = (ENV['MESSAGE_SIZE'] || 1000).to_i
 

--- a/benchmark/websocket-benchmark.rb
+++ b/benchmark/websocket-benchmark.rb
@@ -133,8 +133,8 @@ rates = (ENV['RATES']&.split&.map{|r| Integer(r)} || RATES)
 duration = (ENV['DURATION'] || 5.0).to_f
 message_size = (ENV['MESSAGE_SIZE'] || 1000).to_i
 
-HEADER = '%5s  %6s/s: send %9s @ %9s/s (%6s%% %6s%%) read %9s @ %9s/s (%6s%%) = %12s/s ~%9s'
-FORMAT = '%5.2fs %6d/s: send %9d @ %9.2f/s (%6.2f%% %6.2f%%) read %9d @ %9.2f/s (%6.2f%%) = %12s/s ~%9.6fs'
+HEADER = '%5s  %6s/s %9s: send @ %9s/s (%6s%% %6s%%) read @ %9s/s (%6s%%) = %12s/s ~%9s'
+FORMAT = '%5.2fs %6d/s %9d: send @ %9.2f/s (%6.2f%% %6.2f%%) read @ %9.2f/s (%6.2f%%) = %12s/s ~%9.6fs'
 
 def si(val)
   if val > 10**9
@@ -148,7 +148,7 @@ def si(val)
   end
 end
 
-puts HEADER % ['time ', 'rate', 'count', 'messages', 'util', 'miss', 'count', 'messages', 'drop', 'bytes', 'latency']
+puts HEADER % ['TIME ', 'RATE', 'COUNT', 'MESSAGES', 'UTIL', 'MISS', 'MESSAGES', 'DROP', 'BYTES', 'LATENCY']
 
 for rate in rates
   options = {
@@ -164,8 +164,8 @@ for rate in rates
   drop_ratio = 1.0 - read_stats[:count].to_f / send_stats[:count].to_f
 
   puts FORMAT % [
-    duration, rate,
-    send_stats[:count], send_stats[:rate], send_stats[:util] * 100.0, send_stats[:miss] * 100.0,
-    read_stats[:count], read_stats[:rate], drop_ratio * 100.0, si(read_stats[:bytes_rate]), read_stats[:latency_avg],
+    duration, rate, send_stats[:count],
+    send_stats[:rate], send_stats[:util] * 100.0, send_stats[:miss] * 100.0,
+    read_stats[:rate], drop_ratio * 100.0, si(read_stats[:bytes_rate]), read_stats[:latency_avg],
   ]
 end

--- a/benchmark/websocket-benchmark.rb
+++ b/benchmark/websocket-benchmark.rb
@@ -79,6 +79,7 @@ def websocket_benchmark_reader(client)
   count = 0
   bytes = 0
   latency_total = 0.0
+  t_start = Time.now
 
   client.read do |message|
     t = Time.now.to_f
@@ -90,11 +91,18 @@ def websocket_benchmark_reader(client)
     latency_total += (t - t_f)
   end
 
+  t_end = Time.now
+
   $logger.info "read done"
 
+  t_total = t_end - t_start
+
   return {
+    time: t_total,
     count: count,
+    rate: count / t_total,
     bytes: bytes,
+    bytes_rate: bytes / t_total,
     latency_avg: latency_total / count,
   }
 end
@@ -125,8 +133,8 @@ rates = (ENV['RATES']&.split&.map{|r| Integer(r)} || RATES)
 duration = (ENV['DURATION'] || 5.0).to_f
 message_size = (ENV['MESSAGE_SIZE'] || 1000).to_i
 
-HEADER = '%5s  %6s/s: send %9s @ %9s/s (%5s%% ~ %5s%%) recv %9s @ %12s/s ~ %9s'
-FORMAT = '%5.2fs %6d/s: send %9d @ %9.2f/s (%5.2f%% ~ %5.2f%%) recv %9d @ %12s/s ~ %9.6fs'
+HEADER = '%5s  %6s/s: send %9s @ %9s/s (%6s%% %6s%%) read %9s @ %9s/s (%6s%%) = %12s/s ~%9s'
+FORMAT = '%5.2fs %6d/s: send %9d @ %9.2f/s (%6.2f%% %6.2f%%) read %9d @ %9.2f/s (%6.2f%%) = %12s/s ~%9.6fs'
 
 def si(val)
   if val > 10**9
@@ -140,7 +148,7 @@ def si(val)
   end
 end
 
-puts HEADER % ['time ', 'rate', 'count', 'messages', 'util', 'miss', 'count', 'bytes', 'avg latency']
+puts HEADER % ['time ', 'rate', 'count', 'messages', 'util', 'miss', 'count', 'messages', 'drop', 'bytes', 'latency']
 
 for rate in rates
   options = {
@@ -153,9 +161,11 @@ for rate in rates
 
   send_stats, read_stats = websocket_benchmark(url, **options)
 
+  drop_ratio = 1.0 - read_stats[:count].to_f / send_stats[:count].to_f
+
   puts FORMAT % [
     duration, rate,
     send_stats[:count], send_stats[:rate], send_stats[:util] * 100.0, send_stats[:miss] * 100.0,
-    read_stats[:count], si(read_stats[:bytes] / send_stats[:time]), read_stats[:latency_avg],
+    read_stats[:count], read_stats[:rate], drop_ratio * 100.0, si(read_stats[:bytes_rate]), read_stats[:latency_avg],
   ]
 end

--- a/benchmark/websocket-echo-server.go
+++ b/benchmark/websocket-echo-server.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"github.com/gorilla/websocket"
-	"io"
 	"log"
 	"net/http"
 )
@@ -14,7 +13,7 @@ var websocketUpgrader = websocket.Upgrader{}
 func websocketEcho(conn *websocket.Conn) error {
 	for {
 		if messageType, data, err := conn.ReadMessage(); err != nil {
-			if err == io.EOF {
+			if websocket.IsCloseError(err, 1000) {
 				break
 			} else {
 				return fmt.Errorf("websocket read: %v", err)
@@ -46,7 +45,9 @@ func EchoHandler(w http.ResponseWriter, r *http.Request) {
 		if err := websocketEcho(websocketConn); err != nil {
 			log.Printf("Websocket echo error: %v", err)
 		} else {
-			log.Printf("Websocket close: %v", r.RemoteAddr)
+			if !options.Quiet {
+				log.Printf("Websocket close: %v", r.RemoteAddr)
+			}
 		}
 	}
 }

--- a/benchmark/websocket-echo-server.go
+++ b/benchmark/websocket-echo-server.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"github.com/gorilla/websocket"
+	"io"
+	"log"
+	"net/http"
+)
+
+var websocketUpgrader = websocket.Upgrader{}
+
+func websocketEcho(conn *websocket.Conn) error {
+	for {
+		if messageType, data, err := conn.ReadMessage(); err != nil {
+			if err == io.EOF {
+				break
+			} else {
+				return fmt.Errorf("websocket read: %v", err)
+			}
+		} else if err := conn.WriteMessage(messageType, data); err != nil {
+			return fmt.Errorf("websocket write: %v", err)
+		} else {
+			if options.Verbose {
+				log.Printf("websocket echo: %v", data)
+			}
+		}
+	}
+
+	return nil
+}
+
+func EchoHandler(w http.ResponseWriter, r *http.Request) {
+	if websocketConn, err := websocketUpgrader.Upgrade(w, r, nil); err != nil {
+		log.Printf("Websocket Upgrade error: %v", err)
+		w.WriteHeader(500)
+		fmt.Fprintf(w, "%v", err)
+	} else {
+		if !options.Quiet {
+			log.Printf("Websocket connect: %v", r.RemoteAddr)
+		}
+
+		defer websocketConn.Close()
+
+		if err := websocketEcho(websocketConn); err != nil {
+			log.Printf("Websocket echo error: %v", err)
+		} else {
+			log.Printf("Websocket close: %v", r.RemoteAddr)
+		}
+	}
+}
+
+var options struct {
+	Listen  string
+	Verbose bool
+	Quiet   bool
+}
+
+func init() {
+	flag.StringVar(&options.Listen, "listen", "localhost:8080", "HOST:PORT")
+	flag.BoolVar(&options.Verbose, "verbose", false, "log echo messages")
+	flag.BoolVar(&options.Quiet, "quiet", false, "do not log connects")
+}
+
+func main() {
+	flag.Parse()
+
+	if !options.Quiet {
+		log.Printf("Websocket listen: %v", options.Listen)
+	}
+
+	http.HandleFunc("/echo", EchoHandler)
+
+	if err := http.ListenAndServe(options.Listen, nil); err != nil {
+		log.Fatalf("http listen: %v", err)
+	}
+}


### PR DESCRIPTION
Preliminary results show a ~100% performance improvement from using the native `websocket_mask` extension: ~3000/s -> ~6000/s before overload

## Results (non-dropping mode)

The benchmarks fail with write timeouts once the client saturates. This is caused by the read thread deadlocking on the blocked socket write with the driver mutex held: #14

### With `websocket-driver` from [`websocket-driver-kontena`](https://github.com/kontena/websocket-driver-ruby/) (pure-ruby `websocket/mask`)

```
TIME     RATE/s     COUNT: send @  MESSAGES/s (  UTIL%   MISS%) read @  MESSAGES/s (  DROP%) =        BYTES/s ~  LATENCY
 5.00s      1/s         5: send @      1.00/s (  0.18%   0.00%) read @      1.00/s (  0.00%) =       1.003K/s ~ 0.002466s
 5.00s     10/s        50: send @     10.00/s (  2.06%   0.00%) read @     10.00/s (  0.00%) =      10.027K/s ~ 0.002729s
 5.00s    100/s       500: send @    100.00/s ( 19.82%   0.00%) read @     99.97/s (  0.00%) =     100.268K/s ~ 0.002686s
 5.00s   1000/s      5000: send @    999.97/s ( 35.95%   0.00%) read @    999.90/s (  0.00%) =       1.003M/s ~ 0.000776s
 5.00s   2500/s     12500: send @   2499.95/s ( 70.05%   0.00%) read @   2499.87/s (  0.00%) =       2.507M/s ~ 0.002333s
 5.00s   3000/s     15000: send @   2999.90/s ( 84.71%   0.00%) read @   2961.51/s (  0.00%) =       2.970M/s ~ 0.458441s
 5.00s   3500/s     17500: send @   3499.63/s ( 88.13%   0.00%) read @   3342.98/s (  0.00%) =       3.353M/s ~ 1.224913s
/home/kontena/kontena/kontena-websocket-client/lib/kontena/websocket/client/connection.rb:25:in `wait_socket_writable!': write timeout after 5.0s (Kontena::Websocket::TimeoutError)
```

### With `websocket-driver` from [`websocket-driver`](https://github.com/faye/websocket-driver-ruby/) (native `websocket_mask` extension)

```
TIME     RATE/s     COUNT: send @  MESSAGES/s (  UTIL%   MISS%) read @  MESSAGES/s (  DROP%) =        BYTES/s ~  LATENCY
 5.00s      1/s         5: send @      1.00/s (  0.11%   0.00%) read @      1.00/s (  0.00%) =       1.003K/s ~ 0.001730s
 5.00s     10/s        50: send @     10.00/s (  1.41%   0.00%) read @     10.00/s (  0.00%) =      10.027K/s ~ 0.002177s
 5.00s    100/s       500: send @    100.00/s ( 11.69%   0.00%) read @     99.98/s (  0.00%) =     100.284K/s ~ 0.001840s
 5.00s   1000/s      5000: send @    999.97/s ( 32.65%   0.00%) read @    999.92/s (  0.00%) =       1.003M/s ~ 0.000576s
 5.00s   2500/s     12500: send @   2499.97/s ( 37.79%   0.00%) read @   2499.87/s (  0.00%) =       2.507M/s ~ 0.000411s
 5.00s   5000/s     25000: send @   4999.87/s ( 73.90%   0.00%) read @   4936.86/s (  0.00%) =       4.952M/s ~ 0.303535s
 5.00s   5500/s     27498: send @   5499.58/s ( 74.16%   0.00%) read @   5376.22/s (  0.00%) =       5.392M/s ~ 0.413898s
 5.00s   6000/s     30000: send @   5999.56/s ( 78.46%   0.00%) read @   5571.35/s (  0.00%) =       5.588M/s ~ 1.175362s
/home/kontena/kontena/kontena-websocket-client/lib/kontena/websocket/client/connection.rb:25:in `wait_socket_writable!': write timeout after 5.0s (Kontena::Websocket::TimeoutError)
```

## Results (drop mode)

Running the `websocket-echo-server` in `-drop` mode, where the server drops messages if it reads them faster than the client reads the echo responses. This shows that the client write thread is starving the read thread, as the write rate keeps increasing, but the read rate declines and messages start getting dropped.

### With `websocket-driver` from [`websocket-driver-kontena`](https://github.com/kontena/websocket-driver-ruby/) (pure-ruby `websocket/mask`)

```
TIME     RATE/s     COUNT: send @  MESSAGES/s (  UTIL%   MISS%) read @  MESSAGES/s (  DROP%) =        BYTES/s ~  LATENCY
 5.00s      1/s         5: send @      1.00/s (  0.16%   0.00%) read @      1.00/s (  0.00%) =       1.003K/s ~ 0.002145s
 5.00s     10/s        50: send @     10.00/s (  1.43%   0.00%) read @     10.00/s (  0.00%) =      10.028K/s ~ 0.002030s
 5.00s    100/s       500: send @    100.00/s ( 16.78%   0.00%) read @     99.99/s (  0.00%) =     100.287K/s ~ 0.002330s
 5.00s   1000/s      5000: send @    999.98/s ( 42.32%   0.00%) read @    999.92/s (  0.00%) =       1.003M/s ~ 0.001917s
 5.00s   2500/s     12500: send @   2500.00/s ( 73.15%   0.00%) read @   2499.86/s (  0.00%) =       2.507M/s ~ 0.003623s
 5.00s   3000/s     15000: send @   2999.87/s ( 85.34%   0.00%) read @   2936.82/s (  0.00%) =       2.946M/s ~ 0.895454s
 5.00s   3500/s     17500: send @   3499.85/s ( 89.54%   0.00%) read @   3312.76/s (  0.00%) =       3.323M/s ~ 1.453292s
 5.00s   4000/s     19378: send @   3875.44/s ( 97.06% 100.00%) read @   1594.71/s ( 56.70%) =       1.599M/s ~ 3.601528s
 5.00s   4500/s     19314: send @   3862.74/s ( 97.07% 100.00%) read @    873.74/s ( 76.75%) =     876.365K/s ~ 4.257373s
 5.00s   6000/s     18770: send @   3753.88/s ( 96.73% 100.00%) read @   1417.77/s ( 60.48%) =       1.422M/s ~ 3.658015s
 5.00s  10000/s     16794: send @   3358.74/s ( 96.07% 100.00%) read @    863.12/s ( 73.24%) =     865.708K/s ~ 4.279212s
```

### With `websocket-driver` from [`websocket-driver`](https://github.com/faye/websocket-driver-ruby/) (native `websocket_mask` extension)

```
TIME     RATE/s     COUNT: send @  MESSAGES/s (  UTIL%   MISS%) read @  MESSAGES/s (  DROP%) =        BYTES/s ~  LATENCY
 5.00s      1/s         5: send @      1.00/s (  0.13%   0.00%) read @      1.00/s (  0.00%) =       1.003K/s ~ 0.001995s
 5.00s     10/s        50: send @     10.00/s (  1.34%   0.00%) read @      9.99/s (  0.00%) =      10.024K/s ~ 0.002143s
 5.00s    100/s       500: send @    100.00/s ( 11.63%   0.00%) read @     99.97/s (  0.00%) =     100.265K/s ~ 0.001838s
 5.00s   1000/s      5000: send @    999.97/s ( 30.20%   0.00%) read @    999.87/s (  0.00%) =       1.003M/s ~ 0.000610s
 5.00s   2500/s     12500: send @   2499.97/s ( 37.82%   0.00%) read @   2499.87/s (  0.00%) =       2.507M/s ~ 0.000536s
 5.00s   5000/s     25000: send @   4999.90/s ( 73.16%   0.00%) read @   4963.86/s (  0.00%) =       4.979M/s ~ 0.196671s
 5.00s   5500/s     27500: send @   5499.88/s ( 73.21%   0.00%) read @   5372.98/s (  0.00%) =       5.389M/s ~ 0.465545s
 5.00s   6000/s     30000: send @   5999.92/s ( 79.53%   0.00%) read @   5070.66/s ( 10.81%) =       5.086M/s ~ 1.182131s
 5.00s   6500/s     32479: send @   6493.83/s ( 83.61%   0.00%) read @   3825.08/s ( 37.21%) =       3.837M/s ~ 1.568008s
 5.00s   7000/s     34989: send @   6997.72/s ( 88.34%   0.00%) read @   2580.66/s ( 61.72%) =       2.588M/s ~ 2.083625s
 5.00s   8000/s     38165: send @   7632.93/s ( 94.77% 100.00%) read @    884.60/s ( 88.10%) =     887.251K/s ~ 4.527284s
 5.00s  10000/s     38030: send @   7605.86/s ( 94.69% 100.00%) read @   1644.86/s ( 77.25%) =       1.650M/s ~ 2.646985s
```