### PR TITLE
spec and fix ping callback without @on_pong

### DIFF
--- a/lib/kontena/websocket/client.rb
+++ b/lib/kontena/websocket/client.rb
@@ -348,7 +348,7 @@ class Kontena::Websocket::Client
           debug "ping-pong at #{ping_at} in #{ping_delay}s"
 
           # XXX: defer call without mutex?
-          @on_pong.call(ping_delay) # TODO: also pass ping_at
+          @on_pong.call(ping_delay) if @on_pong # TODO: also pass ping_at
         end
       end
     end


### PR DESCRIPTION
Fixes #19

```
Failures:

  1) Kontena::Websocket::Client with a connected driver #ping sends ping without callback on pong
     Failure/Error: @on_pong.call(ping_delay) # TODO: also pass ping_at
     
     NoMethodError:
       undefined method `call' for nil:NilClass
       Did you mean?  caller
     # ./lib/kontena/websocket/client.rb:351:in `block (2 levels) in ping'
     # ./spec/kontena/websocket/client_spec.rb:489:in `block (4 levels) in <top (required)>'
```